### PR TITLE
text_ Refactor Demo

### DIFF
--- a/core/field.js
+++ b/core/field.js
@@ -725,7 +725,10 @@ Blockly.Field.prototype.getScaledBBox_ = function() {
  * @protected
  */
 Blockly.Field.prototype.getDisplayText_ = function() {
-  var text = this.text_;
+  // The field will now generate the display text based on the display value.
+  // The text no longer needs to be set explicitly. Booyah!
+  var text = this.displayValue_.toString();
+
   if (!text) {
     // Prevent the field from disappearing if empty.
     return Blockly.Field.NBSP;
@@ -885,6 +888,10 @@ Blockly.Field.prototype.doClassValidation_ = function(newValue) {
  * @protected
  */
 Blockly.Field.prototype.doValueUpdate_ = function(newValue) {
+  // If the value is valid that is the value we want to be displayed. So set
+  // the display value to the new value.
+  this.displayValue_ = newValue;
+
   this.value_ = newValue;
   this.isDirty_ = true;
   // For backwards compatibility.
@@ -900,7 +907,14 @@ Blockly.Field.prototype.doValueUpdate_ = function(newValue) {
  */
 Blockly.Field.prototype.doValueInvalid_ = function(_invalidValue) {
   // NOP
+
+  // This function still does nothing. This means that by default fields
+  // will still do nothing when they recieve an invalid input. Meaning that
+  // they continue to display the last valid value.
 };
+
+// Now our date picker should work as expected. And it does:
+// https://i.imgur.com/nLTyqBc.gif
 
 /**
  * Handle a mouse down event on a field.

--- a/demos/custom-fields/field_turtle.js
+++ b/demos/custom-fields/field_turtle.js
@@ -194,7 +194,13 @@ CustomFields.FieldTurtle.prototype.doValueUpdate_ = function(newValue) {
   // newValue, and its this.isDirty_ property to true. The isDirty_ property
   // tells the setValue function whether the field needs to be re-rendered.
   CustomFields.FieldTurtle.superClass_.doValueUpdate_.call(this, newValue);
+
+  // This is the first important place where the display value is set.
+  // The display value is the value displayed on the block (as we've already
+  // discussed).
+  // Because want to display valid values, we need to update this property here.
   this.displayValue_ = newValue;
+
   // Since this field has custom UI for invalid values, we also want to make
   // sure it knows it is now valid.
   this.isValueInvalid_ = false;
@@ -211,13 +217,24 @@ CustomFields.FieldTurtle.prototype.doValueInvalid_ = function(invalidValue) {
   // We want the value to be displayed like normal.
   // But we want to flag it as invalid, so the render_ function knows to
   // make the borderRect_ red.
+
+  // This is the second important place where the display value is set.
+  // Because we also want the field to display invalid values, we need to
+  // update this property here.
+  // Note how the value_ property does not get updated, because it should
+  // always remain valid.
   this.displayValue_ = invalidValue;
+
   this.isDirty_ = true;
   this.isValueInvalid_ = true;
 };
 
 // Updates the field's on-block display based on the current display value.
 CustomFields.FieldTurtle.prototype.render_ = function() {
+  // Observe how the rendering is always based on the display value.
+  // If the input value was valid, the display value will be that valid input.
+  // If the input value was invalid, the display value will be that invalid
+  // input.
   var value = this.displayValue_;
 
   // Always do editor updates inside render. This makes sure the editor
@@ -287,7 +304,19 @@ CustomFields.FieldTurtle.prototype.render_ = function() {
 };
 
 CustomFields.FieldTurtle.prototype.renderEditor_ = function() {
+  // Editor rendering follows the same principle as on-block rendering.
   var value = this.displayValue_;
+
+  // These four instances show how we have solved the problem by adding a single
+  // property, things are now rendered based on the displayValue_ instead of
+  // simply the value_.
+
+  // Other references to displayValue_ are either:
+  //   A) Used as a shortcut. The doClassValidation_ function allows you to
+  //   pass partially-defined values. It then fills in the undefined parts
+  //   based on the displayValue_. This is specific to the turtle field.
+  //   B) Used to initialize the editor (it follows the same principles as
+  //   rendering).
 
   // .textElement is a property assigned to the element.
   // It allows the text to be edited without destroying the warning icon.


### PR DESCRIPTION
This is a demonstration of one method for refactoring the text_ property of fields, as discussed in this issue: https://github.com/google/blockly/issues/2720

I have posted it as a PR because I figured that was the easiest way to discuss the changes. If there is a better place to put this please let me know and I will change it :D

I have also added explanatory comments throughout the code that are meant to be read _in order_. Please look through each commit in this PR in the order that it was committed. Namely:
1) Turtle field explanation.
2) Added support for displaying invalid values to the date field.
3) Added display value support to the abstract field class.
4) Fixed the text input field.

Note for <sam> I do believe we are on the same page about how the Turtle field works, but I wanted to include an explanation of it just in case. I think it might also be a good place to ask questions.

Thank you for taking the time to look at this*! I really appreciate everyone support for my ideas!

*Don't feel like you have to look at it today though, I do realize it's Friday :P